### PR TITLE
update gradle library version for jdk 11

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/library/src/test/java/foundation/icon/icx/IconServiceVCRTest.java
+++ b/library/src/test/java/foundation/icon/icx/IconServiceVCRTest.java
@@ -52,10 +52,10 @@ public class IconServiceVCRTest {
     @BeforeEach
     void setUp() {
         scoreAddress = new Address("cxcc7ef86cdae93a89b6c08206a7962bcb9abb7bf4");
-        HttpLoggingInterceptor loggning = new HttpLoggingInterceptor();
-        loggning.setLevel(HttpLoggingInterceptor.Level.BODY);
+        HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+        logging.setLevel(HttpLoggingInterceptor.Level.BODY);
         OkHttpClient httpClient = new OkHttpClient.Builder()
-                .addInterceptor(loggning)
+                .addInterceptor(logging)
                 .build();
         iconService = new IconService(new HttpProvider(httpClient, URL));
         wallet = KeyWallet.load(new Bytes(PRIVATE_KEY_STRING));
@@ -269,10 +269,10 @@ public class IconServiceVCRTest {
 
     @Test
     void testV2() throws IOException {
-        HttpLoggingInterceptor loggning = new HttpLoggingInterceptor();
-        loggning.setLevel(HttpLoggingInterceptor.Level.BODY);
+        HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+        logging.setLevel(HttpLoggingInterceptor.Level.BODY);
         OkHttpClient httpClient = new OkHttpClient.Builder()
-                .addInterceptor(loggning)
+                .addInterceptor(logging)
                 .build();
         HttpProvider provider = new HttpProvider(httpClient, TEST_V2_URL);
 

--- a/quickstart/src/main/java/foundation/icon/icx/DeployTokenExample.java
+++ b/quickstart/src/main/java/foundation/icon/icx/DeployTokenExample.java
@@ -47,10 +47,10 @@ public class DeployTokenExample {
     public DeployTokenExample() {
         // Logs HTTP request and response data
         // https://github.com/square/okhttp/tree/master/okhttp-logging-interceptor
-        HttpLoggingInterceptor loggning = new HttpLoggingInterceptor();
-        loggning.setLevel(HttpLoggingInterceptor.Level.BODY);
+        HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+        logging.setLevel(HttpLoggingInterceptor.Level.BODY);
         OkHttpClient httpClient = new OkHttpClient.Builder()
-//				.addInterceptor(loggning)
+//				.addInterceptor(logging)
                 .build();
 
         // Creates an instance of IconService using the HTTP provider

--- a/quickstart/src/main/java/foundation/icon/icx/IcxTransactionExample.java
+++ b/quickstart/src/main/java/foundation/icon/icx/IcxTransactionExample.java
@@ -42,10 +42,10 @@ public class IcxTransactionExample {
     public IcxTransactionExample() {
         // Logs HTTP request and response data
         // https://github.com/square/okhttp/tree/master/okhttp-logging-interceptor
-        HttpLoggingInterceptor loggning = new HttpLoggingInterceptor();
-        loggning.setLevel(HttpLoggingInterceptor.Level.BODY);
+        HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+        logging.setLevel(HttpLoggingInterceptor.Level.BODY);
         OkHttpClient httpClient = new OkHttpClient.Builder()
-//				.addInterceptor(loggning)
+//				.addInterceptor(logging)
                 .build();
 
         // Creates an instance of IconService using the HTTP provider

--- a/quickstart/src/main/java/foundation/icon/icx/SyncBlockExample.java
+++ b/quickstart/src/main/java/foundation/icon/icx/SyncBlockExample.java
@@ -44,10 +44,10 @@ public class SyncBlockExample {
     public SyncBlockExample() {
         // Logs HTTP request and response data
         // https://github.com/square/okhttp/tree/master/okhttp-logging-interceptor
-        HttpLoggingInterceptor loggning = new HttpLoggingInterceptor();
-        loggning.setLevel(HttpLoggingInterceptor.Level.BODY);
+        HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+        logging.setLevel(HttpLoggingInterceptor.Level.BODY);
         OkHttpClient httpClient = new OkHttpClient.Builder()
-//				.addInterceptor(loggning)
+//				.addInterceptor(logging)
                 .build();
 
         // Creates an instance of IconService using the HTTP provider

--- a/quickstart/src/main/java/foundation/icon/icx/TokenTransactionExample.java
+++ b/quickstart/src/main/java/foundation/icon/icx/TokenTransactionExample.java
@@ -45,10 +45,10 @@ public class TokenTransactionExample {
     public TokenTransactionExample() {
         // Logs HTTP request and response data
         // https://github.com/square/okhttp/tree/master/okhttp-logging-interceptor
-        HttpLoggingInterceptor loggning = new HttpLoggingInterceptor();
-        loggning.setLevel(HttpLoggingInterceptor.Level.BODY);
+        HttpLoggingInterceptor logging = new HttpLoggingInterceptor();
+        logging.setLevel(HttpLoggingInterceptor.Level.BODY);
         OkHttpClient httpClient = new OkHttpClient.Builder()
-//				.addInterceptor(loggning)
+//				.addInterceptor(logging)
                 .build();
 
         // Creates an instance of IconService using the HTTP provider


### PR DESCRIPTION
gradle build failed in intelliJ with openjdk 11.
update gradle version `4.7` to `4.10.2`.
ref) https://github.com/gradle/gradle/issues/4860

and fixed typos.