### PR TITLE
Fix an RpcValueException error message

### DIFF
--- a/library/src/main/java/foundation/icon/icx/transport/jsonrpc/RpcItem.java
+++ b/library/src/main/java/foundation/icon/icx/transport/jsonrpc/RpcItem.java
@@ -35,7 +35,7 @@ public interface RpcItem {
 
     default RpcArray asArray() {
         if (this instanceof RpcArray) return (RpcArray) this;
-        throw new RpcValueException("This item can not be converted to RpcValue");
+        throw new RpcValueException("This item can not be converted to RpcArray");
     }
 
     default RpcValue asValue() {


### PR DESCRIPTION
The RpcValueException error message for casting the instance as an RpcArray is incorrect