### PR TITLE
Support logs field in Block/EventNotification

### DIFF
--- a/library/src/main/java/foundation/icon/icx/data/BlockNotification.java
+++ b/library/src/main/java/foundation/icon/icx/data/BlockNotification.java
@@ -21,6 +21,8 @@ import foundation.icon.icx.transport.jsonrpc.RpcItem;
 import foundation.icon.icx.transport.jsonrpc.RpcObject;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 
 public class BlockNotification {
     private final RpcObject properties;
@@ -84,5 +86,21 @@ public class BlockNotification {
 
     public static BigInteger asInteger(RpcItem item) {
         return item != null ? item.asInteger() : null;
+    }
+
+    public List<TransactionResult.EventLog> getLogs() {
+        RpcItem item = properties.getItem("logs");
+        List<TransactionResult.EventLog> eventLogs = new ArrayList<>();
+        if (item != null) {
+            for (RpcItem rpcItem : item.asArray()) {
+                eventLogs.add(new TransactionResult.EventLog(rpcItem.asObject()));
+            }
+        }
+        return eventLogs;
+    }
+
+    @Override
+    public String toString() {
+        return "BlockNotification{Properties="+properties+"}";
     }
 }

--- a/library/src/main/java/foundation/icon/icx/data/EventNotification.java
+++ b/library/src/main/java/foundation/icon/icx/data/EventNotification.java
@@ -21,6 +21,8 @@ import foundation.icon.icx.transport.jsonrpc.RpcItem;
 import foundation.icon.icx.transport.jsonrpc.RpcObject;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 
 public class EventNotification {
     private final RpcObject properties;
@@ -58,5 +60,21 @@ public class EventNotification {
 
     public static BigInteger asInteger(RpcItem item) {
         return item != null ? item.asInteger() : null;
+    }
+
+    public List<TransactionResult.EventLog> getLogs() {
+        RpcItem item = properties.getItem("logs");
+        List<TransactionResult.EventLog> eventLogs = new ArrayList<>();
+        if (item != null) {
+            for (RpcItem rpcItem : item.asArray()) {
+                eventLogs.add(new TransactionResult.EventLog(rpcItem.asObject()));
+            }
+        }
+        return eventLogs;
+    }
+
+    @Override
+    public String toString() {
+        return "EventNotification{Properties="+properties+"}";
     }
 }


### PR DESCRIPTION
Although it supports inclusion of logs in each monitoring API, notification classes doesn't support the field, "logs". So, let it handle it properly.